### PR TITLE
Closes #35: Docs segment revenue share

### DIFF
--- a/docs/example.ipynb
+++ b/docs/example.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,9 +28,9 @@
     "import numpy as np\n",
     "import random\n",
     "from datetime import datetime, timedelta\n",
-    "import random\n",
     "\n",
     "from salesanalyzer.sales_summary_statistics import sales_summary_statistics\n",
+    "from salesanalyzer.segment_revenue_share import segment_revenue_share\n",
     "from salesanalyzer.predict_sales import predict_sales"
    ]
   },
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,6 +306,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Get Revenue Share for each Product Category\n",
+    "\n",
+    "Another feature of `saleanalyzer`, the `segment_revenue_share` function, segments products into three categories (cheap < medium < expensive) — based on their price, and calculates the respective share of total revenue contributed by each segment. This function is particularly useful for analyzing product sales data and understanding revenue distribution across different pricing tiers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "revenue_share = segment_revenue_share(sample_data, price_col='UnitPrice', quantity_col='Quantity')\n",
+    "print(revenue_share)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Predict Future Sales\n",
     "\n",
     "Now that you have a good summary of your **past** sales, say, you want to peek into the **future** and predict how your products will sell in a month, 2 months or even a year? You can do this with `predict_sales()` function. This function uses a Random Forest machine learning model to make predictions on your specified target (e.g. quantity sold). The output will be a dictionary with predicted values, and the model's performance score (Mean Squared Error).\n",
@@ -368,7 +387,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "salesanalyzser",
+   "display_name": "salesanalyzer-ObHKNrRj-py3.11",
    "language": "python",
    "name": "python3"
   },
@@ -382,7 +401,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/src/salesanalyzer/segment_revenue_share.py
+++ b/src/salesanalyzer/segment_revenue_share.py
@@ -87,5 +87,16 @@ def segment_revenue_share(sales_data,
             (revenue_share['TotalRevenue'] / total_revenue) * 100
         )
 
-    revenue_share = revenue_share.round({'TotalRevenue': 2, 'RevenueShare (%)': 2})
+    # Round to 2 decimal places
+    revenue_share = revenue_share.round(
+        {'TotalRevenue': 2, 'RevenueShare (%)': 2}
+        )
+
+    # Ensure the segments are in order: cheap, medium, expensive
+    segment_order = ['cheap', 'medium', 'expensive']
+    revenue_share['PriceSegment'] = pd.Categorical(
+        revenue_share['PriceSegment'], categories=segment_order, ordered=True)
+
+    revenue_share = revenue_share.sort_values(by='PriceSegment').reset_index(drop=True)
+    
     return revenue_share


### PR DESCRIPTION
- updated example.ipynb with `segment_revenue_share` function
- updated `segment_revenue_share` function to sort product categories: `cheap < medium < expensive`